### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   create-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dauffrey/CeliacTaxAssist/security/code-scanning/1](https://github.com/dauffrey/CeliacTaxAssist/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Since the workflow involves creating and pushing tags, as well as updating and committing files, it requires `contents: write`. Adding this permission ensures the workflow has the necessary access while limiting it to only what is required.

The `permissions` block will be added at the root of the workflow file, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
